### PR TITLE
Add ability to offset the first button of a bar

### DIFF
--- a/ActionBar.lua
+++ b/ActionBar.lua
@@ -180,7 +180,7 @@ local customExitButton = {
 }
 
 -- Update the number of buttons in our bar, creating new ones if necessary
-function ActionBar:UpdateButtons(numbuttons)
+function ActionBar:UpdateButtons(numbuttons, offset)
 	if numbuttons then
 		self.config.buttons = min(numbuttons, 12)
 	else
@@ -188,14 +188,26 @@ function ActionBar:UpdateButtons(numbuttons)
 	end
 
 	local buttons = self.buttons or {}
+	local updateBindings = (numbuttons > #buttons) or offset ~= self.config.buttonOffset
+	local updateStartValue = #buttons + 1
+	if offset ~= self.config.buttonOffset then
+		updateStartValue = 1
+	end
 
-	local updateBindings = (numbuttons > #buttons)
+	if offset then
+		self.config.buttonOffset = min(offset, 11)
+	else
+		offset = min(self.config.buttonOffset, 11)
+	end
+
 	-- create more buttons if needed
-	for i = (#buttons+1), numbuttons do
-		local absid = (self.id - 1) * 12 + i
-		buttons[i] = LAB10:CreateButton(absid, format("BT4Button%d", absid), self, nil)
+	for i = updateStartValue, numbuttons do
+		local absid = (self.id - 1) * 12 + (i + offset - 1) % 12 + 1
+		if buttons[i] == nil then
+			buttons[i] = LAB10:CreateButton(absid, format("BT4Button%d", absid), self, nil)
+		end
 		for k = 1,14 do
-			buttons[i]:SetState(k, "action", (k - 1) * 12 + i)
+			buttons[i]:SetState(k, "action", (k - 1) * 12 + (i + offset - 1) % 12 + 1)
 		end
 		buttons[i]:SetState(0, "action", absid)
 
@@ -250,8 +262,17 @@ function ActionBar:GetButtons()
 	return self.config.buttons
 end
 
+-- get the current number of buttons
+function ActionBar:GetButtonOffset()
+	return self.config.buttonOffset
+end
+
 -- set the number of buttons and refresh layout
 ActionBar.SetButtons = ActionBar.UpdateButtons
+
+function ActionBar:SetButtonOffset(offset)
+	return self:UpdateButtons(self.config.buttons, offset)
+end
 
 function ActionBar:GetEnabled()
 	return true

--- a/ActionBars.lua
+++ b/ActionBars.lua
@@ -16,6 +16,7 @@ local abdefaults = {
 	['**'] = Bartender4:Merge({
 		enabled = true,
 		buttons = 12,
+		buttonOffset = 0,
 		hidemacrotext = false,
 		showgrid = false,
 		flyoutDirection = "UP",

--- a/ButtonBar.lua
+++ b/ButtonBar.lua
@@ -161,7 +161,7 @@ function ButtonBar:UpdateButtonLayout()
 
 	-- bail out if the bar has no buttons, for whatever reason
 	-- (eg. stanceless class, or no stances learned yet, etc.)
-	if numbuttons == 0 then return end
+	if numbuttons <= 0 then return end
 
 	local Rows = self:GetRows()
 	local ButtonPerRow = math_ceil(numbuttons / Rows) -- just a precaution

--- a/Options/ActionBar.lua
+++ b/Options/ActionBar.lua
@@ -25,6 +25,7 @@ do
 		enabled = "Enabled",
 		grid = "Grid",
 		flyoutDirection = "FlyoutDirection",
+		buttonOffset = "ButtonOffset",
 	}
 
 	-- retrieves a valid bar object from the modules actionbars table
@@ -90,6 +91,15 @@ function module:GetOptionsObject()
 				desc = L["Number of buttons."],
 				type = "range",
 				min = 1, max = 12, step = 1,
+				set = optSetter,
+				get = optGetter,
+			},
+			buttonOffset = {
+				order = 51,
+				name = L["Button Offset"],
+				desc = L["How many buttons to offset to the left."],
+				type = "range",
+				min = 0, max = 11, step = 1,
 				set = optSetter,
 				get = optGetter,
 			},


### PR DESCRIPTION
The goal of this pull request is to add the ability to offset the first button of a bar.

![BT4OffsetDemo](https://user-images.githubusercontent.com/7500492/86542112-dc073d80-bf12-11ea-9c2e-ec64ea089940.gif)

This would allow users to split an action bar page into multiple bars of unequal size like

![image](https://user-images.githubusercontent.com/7500492/86542138-27215080-bf13-11ea-99d2-dad5a9817875.png)

It allows using all the slots of all your bars, while making your bars more customizable.


Although I know this is a rare desire/need, I feel like it wouldn't hurt, and I know I like this change, since before then I could not have this look and still use all my bar pages at their full potential.

Please tell me if you disagree or if you would like anything to be changed before pulling.