### PR TITLE
Add the ability for a bar to grow horizontally in both directions

### DIFF
--- a/Bar.lua
+++ b/Bar.lua
@@ -55,7 +55,13 @@ do
 
 	local function barReAnchorForSnap(self)
 		local x,y,anchor = nil, nil, self:GetAnchor()
-		x = (self.config.position.growHorizontal == "RIGHT") and self:GetLeft() or self:GetRight()
+		if self.config.position.growHorizontal == "RIGHT" then
+			x = self:GetLeft()
+		elseif self.config.position.growHorizontal == "LEFT" then
+			x = self:GetRight()
+		elseif self.config.position.growHorizontal == "BOTH" then
+			x = self:GetCenter()
+		end
 		y = (self.config.position.growVertical == "DOWN") and self:GetTop() or self:GetBottom()
 		self:ClearSetPoint(anchor, UIParent, "BOTTOMLEFT", x, y)
 		self:SetWidth(self.overlay:GetWidth())
@@ -64,7 +70,13 @@ do
 
 	local function barReAnchorNormal(self)
 		local x,y,anchor = nil, nil, self:GetAnchor()
-		x = (self.config.position.growHorizontal == "RIGHT") and self:GetLeft() or self:GetRight()
+		if self.config.position.growHorizontal == "RIGHT" then
+			x = self:GetLeft()
+		elseif self.config.position.growHorizontal == "LEFT" then
+			x = self:GetRight()
+		elseif self.config.position.growHorizontal == "BOTH" then
+			x = self:GetCenter()
+		end
 		y = (self.config.position.growVertical == "DOWN") and self:GetTop() or self:GetBottom()
 		self:ClearSetPoint(anchor, UIParent, "BOTTOMLEFT", x, y)
 		self:SetWidth(1)
@@ -230,7 +242,13 @@ function Bar:ApplyConfig(config)
 end
 
 function Bar:GetAnchor()
-	return ((self.config.position.growVertical == "DOWN") and "TOP" or "BOTTOM") .. ((self.config.position.growHorizontal == "RIGHT") and "LEFT" or "RIGHT")
+	local anchor = (self.config.position.growVertical == "DOWN") and "TOP" or "BOTTOM"
+	if self.config.position.growHorizontal == "RIGHT" then
+		anchor = anchor .. "LEFT"
+	elseif self.config.position.growHorizontal == "LEFT" then
+		anchor = anchor .. "RIGHT"
+	end
+	return anchor
 end
 
 function Bar:AnchorOverlay()

--- a/ButtonBar.lua
+++ b/ButtonBar.lua
@@ -181,11 +181,14 @@ function ButtonBar:UpdateButtonLayout()
 	if self.config.position.growHorizontal == "RIGHT" then
 		h1, h2 = "LEFT", "RIGHT"
 		xOff = 5
-	else
+	elseif self.config.position.growHorizontal == "LEFT" then
 		h1, h2 = "RIGHT", "LEFT"
 		xOff = -3
 
 		hpad = -hpad
+	elseif self.config.position.growHorizontal == "BOTH" then
+		h1, h2 = "LEFT", "RIGHT"
+		xOff = (self.button_width + hpad) * (ButtonPerRow - 1) / -2
 	end
 
 	if self.config.position.growVertical == "DOWN" then

--- a/Options/ButtonBar.lua
+++ b/Options/ButtonBar.lua
@@ -106,7 +106,7 @@ function ButtonBar:GetOptionObject()
 			name = L["Horizontal Growth"],
 			desc = L["Horizontal growth direction for this bar."],
 			type = "select",
-			values = {LEFT = L["Left"], RIGHT = L["Right"]},
+			values = {LEFT = L["Left"], RIGHT = L["Right"], BOTH = L["Both"]},
 			set = optSetter,
 			get = optGetter,
 		},


### PR DESCRIPTION
I recently realized there was no way for a bar to expand in both directions at the same time.
This is what this PR is about ! Allowing the horizontal growth of a bar to be, `Left`, `Right` or `Both`

This is the result : 
![Bartender4HGrowthBoth](https://user-images.githubusercontent.com/7500492/100524899-44093980-31bc-11eb-90ea-a9fbf4811e8e.gif)

You will notice I also changed those one liners, as with one more option (possibly two if you'd like me to implement something similar for verticality), they would've become really hard to read.

Don't hesitate to tell me if you'd like me to change something
