### PR TITLE
ActionBarController_GetCurrentActionBarState() instead of CURRENT_ACTION_BAR_STATE

### DIFF
--- a/Bartender4.lua
+++ b/Bartender4.lua
@@ -288,7 +288,7 @@ function Bartender4:UpdateBlizzardVehicle()
 	if self.db.profile.blizzardVehicle then
 		--MainMenuBar:SetParent(UIParent)
 		OverrideActionBar:SetParent(UIParent)
-		if CURRENT_ACTION_BAR_STATE ~= LE_ACTIONBAR_STATE_OVERRIDE then
+		if ActionBarController_GetCurrentActionBarState() ~= LE_ACTIONBAR_STATE_OVERRIDE then
 			OverrideActionBar:Hide()
 		end
 		if not self.vehicleController then

--- a/MicroMenu.lua
+++ b/MicroMenu.lua
@@ -112,7 +112,7 @@ function MicroMenuMod:PET_BATTLE_CLOSE()
 end
 
 function MicroMenuMod:ActionBarController_UpdateAll()
-	if self.ownedByUI and CURRENT_ACTION_BAR_STATE == LE_ACTIONBAR_STATE_MAIN and not (C_PetBattles and C_PetBattles.IsInBattle()) then
+	if self.ownedByUI and ActionBarController_GetCurrentActionBarState() == LE_ACTIONBAR_STATE_MAIN and not (C_PetBattles and C_PetBattles.IsInBattle()) then
 		UpdateMicroButtonsParent(self.bar)
 		self:MicroMenuBarShow()
 	end


### PR DESCRIPTION
Using ActionBarController_GetCurrentActionBarState() instead of CURRENT_ACTION_BAR_STATE, which is no longer global.
(Noticed this because the OverrideActionBar always got hidden when Bartender updated while OverrideActionBar was visible.)