### PR TITLE
Add additional support for keybinds and overrides of default bars

### DIFF
--- a/ActionBar.lua
+++ b/ActionBar.lua
@@ -71,9 +71,16 @@ function ActionBar:UpdateButtonConfig()
 	self.buttonConfig.clickOnDown = Bartender4.db.profile.onkeydown
 	self.buttonConfig.flyoutDirection = self.config.flyoutDirection
 
-	if tonumber(self.id) == 1 then
+	local bar = ({
+		[1] = "ACTIONBUTTON",
+		[3] = "MULTIACTIONBAR3BUTTON", --MultiBarRightButton
+		[4] = "MULTIACTIONBAR4BUTTON", --MultiBarLeftButton
+		[5] = "MULTIACTIONBAR2BUTTON", --MultiBarBottomRightButton
+		[6] = "MULTIACTIONBAR1BUTTON", --MultiBarBottomLeftButton
+	})[tonumber(self.id) or 0]
+	if bar then
 		for i, button in self:GetAll() do
-			self.buttonConfig.keyBoundTarget = format("ACTIONBUTTON%d", i)
+			self.buttonConfig.keyBoundTarget = format("%s%d", bar, i)
 			button:UpdateConfig(self.buttonConfig)
 		end
 	else

--- a/ActionBars.lua
+++ b/ActionBars.lua
@@ -155,16 +155,23 @@ function BT4ActionBars:UpdateButtons(force)
 end
 
 function BT4ActionBars:ReassignBindings()
-	if InCombatLockdown() then return end
-	if not self.actionbars or not self.actionbars[1] then return end
-	local frame = self.actionbars[1]
-	ClearOverrideBindings(frame)
-	for i = 1,min(#frame.buttons, 12) do
-		local button, real_button = ("ACTIONBUTTON%d"):format(i), ("BT4Button%d"):format(i)
-		for k=1, select('#', GetBindingKey(button)) do
-			local key = select(k, GetBindingKey(button))
-			if key and key ~= "" then
-				SetOverrideBindingClick(frame, false, key, real_button)
+	if InCombatLockdown() or not self.actionbars then return end
+
+	for bar,bind in pairs({
+		[1] = "ACTIONBUTTON",
+		[3] = "MULTIACTIONBAR3BUTTON", --MultiBarRightButton
+		[4] = "MULTIACTIONBAR4BUTTON", --MultiBarLeftButton
+		[5] = "MULTIACTIONBAR2BUTTON", --MultiBarBottomRightButton
+		[6] = "MULTIACTIONBAR1BUTTON", --MultiBarBottomLeftButton
+	}) do
+		local frame = self.actionbars[bar]
+		if frame then
+			ClearOverrideBindings(frame)
+			for i=1,min(#frame.buttons, 12) do
+				local button, real_button = ("%s%d"):format(bind, i), ("BT4Button%d"):format((bar-1)*12 + i)
+				for _,key in pairs({GetBindingKey(button)}) do
+					SetOverrideBindingClick(frame, false, key, real_button)
+				end
 			end
 		end
 	end


### PR DESCRIPTION
This PR adds support for the other four additional default blizzard action bars. Both updating keyBoundTarget to display the keybind on the action bars and SetOverrideBindingClick BT4Buttons for proper keyfall handling and overlays.

The bar index button lookup should be a global so it's not declared in two separate places but I wasn't sure your design style. Please feel free to modify. I've tested these changes locally in game and are working as expected. Cheers!