### PR TITLE
Allow change vertical alignment for bag bar buttons

### DIFF
--- a/BagBar.lua
+++ b/BagBar.lua
@@ -26,6 +26,7 @@ local BagBar = setmetatable({}, {__index = ButtonBar})
 
 local defaults = { profile = Bartender4:Merge({
 	enabled = true,
+	verticalAlignment = "CENTER",
 	keyring = true,
 	onebag = false,
 	onebagreagents = true,

--- a/BagBar.lua
+++ b/BagBar.lua
@@ -26,7 +26,7 @@ local BagBar = setmetatable({}, {__index = ButtonBar})
 
 local defaults = { profile = Bartender4:Merge({
 	enabled = true,
-	verticalAlignment = "CENTER",
+	verticalAlignment = "BOTTOM",
 	keyring = true,
 	onebag = false,
 	onebagreagents = true,

--- a/BagBarClassic.lua
+++ b/BagBarClassic.lua
@@ -28,7 +28,7 @@ local BagBar = setmetatable({}, {__index = ButtonBar})
 
 local defaults = { profile = Bartender4:Merge({
 	enabled = true,
-	verticalAlignment = "CENTER",
+	verticalAlignment = "BOTTOM",
 	keyring = true,
 	onebag = false,
 	visibility = {

--- a/BagBarClassic.lua
+++ b/BagBarClassic.lua
@@ -28,6 +28,7 @@ local BagBar = setmetatable({}, {__index = ButtonBar})
 
 local defaults = { profile = Bartender4:Merge({
 	enabled = true,
+	verticalAlignment = "CENTER",
 	keyring = true,
 	onebag = false,
 	visibility = {

--- a/ButtonBar.lua
+++ b/ButtonBar.lua
@@ -203,6 +203,17 @@ function ButtonBar:UpdateButtonLayout()
 		vpad = -vpad
 	end
 
+	local vprev = "TOP"
+	-- BagBar button alignment
+	if self.config.verticalAlignment then
+		if self.config.verticalAlignment == "CENTER" then
+			vprev = ""
+		elseif self.config.verticalAlignment == "BOTTOM" then
+			vprev = "BOTTOM"
+		end
+		-- otherwise, top
+	end
+
 	-- anchor button 1
 	local anchor = self:GetAnchor()
 	buttons[1]:ClearSetPoint(anchor, self, anchor, xOff - (self.hpad_offset or 0), yOff - (self.vpad_offset or 0))
@@ -214,7 +225,8 @@ function ButtonBar:UpdateButtonLayout()
 			buttons[i]:ClearSetPoint(v1 .. h1, buttons[i-ButtonPerRow], v2 .. h1, 0, -vpad)
 		-- align to the previous button
 		else
-			buttons[i]:ClearSetPoint("TOP" .. h1, buttons[i-1], "TOP" .. h2, hpad, buttons[i].bt4_yoffset or 0)
+			--buttons[i]:ClearSetPoint("TOP" .. h1, buttons[i-1], "TOP" .. h2, hpad, buttons[i].bt4_yoffset or 0)
+			buttons[i]:ClearSetPoint(vprev .. h1, buttons[i-1], vprev .. h2, hpad, buttons[i].bt4_yoffset or 0)
 		end
 	end
 

--- a/Options/BagBar.lua
+++ b/Options/BagBar.lua
@@ -28,6 +28,17 @@ function BagBarMod:SetupOptions()
 		}
 		self.optionobject:AddElement("general", "enabled", enabled)
 
+		local verticalAlignment = {
+			type = "select",
+			order = 79,
+			name = L["Vertical Alignment"],
+			desc = L["Vertical alignment for this bar."],
+			get = function() return self.db.profile.verticalAlignment end,
+			set = function(info, state) self.db.profile.verticalAlignment = state; self.bar:UpdateButtonLayout() end,
+			values = { TOP = L["TOP"], CENTER = L["CENTER"], BOTTOM = L["BOTTOM"] },
+		}
+		self.optionobject:AddElement("general", "verticalAlignment", verticalAlignment)
+
 		local onebag = {
 			type = "toggle",
 			order = 80,

--- a/Options/Presets.lua
+++ b/Options/Presets.lua
@@ -200,6 +200,7 @@ local function BuildClassicBlizzardProfile()
 
 	config = Bartender4.db:GetNamespace("BagBar").profile
 	config.onebag = false
+	config.verticalAlignment = "TOP"
 	SetBarLocation( config, "BOTTOM", 345, 38.5 )
 
 	config = Bartender4.db:GetNamespace("MicroMenu").profile

--- a/Options/PresetsClassic.lua
+++ b/Options/PresetsClassic.lua
@@ -249,9 +249,10 @@ local function BuildBlizzardProfile()
 		config = Bartender4.db:GetNamespace("BagBar").profile
 		config.onebag = false
 		config.keyring = showKeyRing
+		config.verticalAlignment = "CENTER"
 		if GetClassicExpansionLevel() >= 2 --[[Wrath]] then
 			config.padding = 4
-			SetBarLocation( config, "BOTTOM", 303, 42)
+			SetBarLocation( config, "BOTTOM", 304, 42)
 		else
 			config.padding = 5
 			SetBarLocation( config, "BOTTOM", 272, 42)


### PR DESCRIPTION
This PR allows the vertical alignment of the bag bar buttons to be changed (eg top, center, bottom). Previously, the buttons were always aligned to the top. This was mainly done so that the bag buttons would fit correctly in the (WoW Classic) Blizzard bar art.

Also, the bag bar in the "Blizzard" preset for Classic was moved slightly (it was previously misaligned by one pixel).

Before (Classic):
![image](https://user-images.githubusercontent.com/24487843/195422587-661630ae-f40c-43b2-b63d-d52387c2b276.png)

After (Classic): 
![image](https://user-images.githubusercontent.com/24487843/195422509-da6016ad-4f0f-4f4f-8258-d896014ae205.png)

Aftter (Retail): 
![image](https://user-images.githubusercontent.com/24487843/195422138-f67a7735-7383-4f49-bbc8-b3fa2d5b3dd2.png)
