### PR TITLE
Fix broken flyout action bar buttons

### DIFF
--- a/ActionBar.lua
+++ b/ActionBar.lua
@@ -344,6 +344,10 @@ function ActionBar:GetFlyoutDirection()
 	return self.config.flyoutDirection
 end
 
+function ActionBar:GetSpellFlyoutDirection()
+	return self.config.flyoutDirection
+end
+
 function ActionBar:SetFlyoutDirection(state)
 	if state ~= nil then
 		self.config.flyoutDirection = state


### PR DESCRIPTION
Currently spells that have flyouts appear to be broken in Bartender. This includes anything like Mage Teleports etc. Works fine with default UI. 

Looks like Blizzard has updated name of the function, in the mixin, to GetSpellFlyoutDirection from GetFlyoutDirection. Include both for classic compatibility.

Associated Lua error is as follows:

```
Interface/FrameXML/SpellFlyout.lua:240: attempt to call method 'GetSpellFlyoutDirection' (a nil value)
[string "=[C]"]: ?
[string "=[C]"]: ?
[string "@Interface/FrameXML/SecureHandlers.lua"]:40: in function <Interface/FrameXML/SecureHandlers.lua:39>
[string "@Interface/FrameXML/SecureHandlers.lua"]:268: in function <Interface/FrameXML/SecureHandlers.lua:263>
[string "=[C]"]: ?
[string "@Interface/FrameXML/SecureHandlers.lua"]:296: in function <Interface/FrameXML/SecureHandlers.lua:279>
[string "=(tail call)"]: ?
```