### PR TITLE
Update 10.0 Masque skinning

### DIFF
--- a/BagBar.lua
+++ b/BagBar.lua
@@ -42,7 +42,7 @@ local noopFunc = function() end
 
 function BagBarMod:OnEnable()
 	if not self.bar then
-		self.bar = setmetatable(Bartender4.ButtonBar:Create("BagBar", self.db.profile, L["Bag Bar"], true), {__index = BagBar})
+		self.bar = setmetatable(Bartender4.ButtonBar:Create("BagBar", self.db.profile, L["Bag Bar"]), {__index = BagBar})
 
 		CharacterReagentBag0Slot.SetBarExpanded = noopFunc
 		CharacterBag3Slot.SetBarExpanded = noopFunc
@@ -81,6 +81,8 @@ BagBar.button_height = 30
 BagBarMod.button_count = 6
 function BagBar:FeedButtons()
 	local count = 1
+	local group = self.MasqueGroup
+
 	if self.buttons then
 		while next(self.buttons) do
 			local btn = table_remove(self.buttons)
@@ -88,44 +90,54 @@ function BagBar:FeedButtons()
 			btn:SetParent(UIParent)
 			btn:ClearSetPoint("CENTER")
 
-			--[[if btn.MasqueButtonData then
-				local group = self.MasqueGroup
+			if btn.MasqueButtonData then
 				group:RemoveButton(btn)
-			end]]
+			end
 		end
 	else
 		self.buttons = {}
 	end
 
+	local btnTypes = {}
+
 	if not self.config.onebag or self.config.onebagreagents then
 		table_insert(self.buttons, CharacterReagentBag0Slot)
+		btnTypes[CharacterReagentBag0Slot] = "ReagentBag"
 		count = count + 1
 	end
 
 	if not self.config.onebag then
 		table_insert(self.buttons, CharacterBag3Slot)
+		btnTypes[CharacterBag3Slot] = "BagSlot"
+
 		table_insert(self.buttons, CharacterBag2Slot)
+		btnTypes[CharacterBag2Slot] = "BagSlot"
+
 		table_insert(self.buttons, CharacterBag1Slot)
+		btnTypes[CharacterBag1Slot] = "BagSlot"
+
 		table_insert(self.buttons, CharacterBag0Slot)
+		btnTypes[CharacterBag0Slot] = "BagSlot"
+
 		count = count + 4
 	end
 
 	table_insert(self.buttons, MainMenuBarBackpackButton)
+	btnTypes[MainMenuBarBackpackButton] = "Backpack"
 
 	for i,v in pairs(self.buttons) do
 		v:SetParent(self)
 		v:Show()
 
-		--[[if Masque then
-			local group = self.MasqueGroup
+		if group then
 			if not v.MasqueButtonData then
 				v.MasqueButtonData = {
 					Button = v,
 					Icon = v.icon
 				}
 			end
-			group:AddButton(v, v.MasqueButtonData, "Item")
-		end]]
+			group:AddButton(v, v.MasqueButtonData, btnTypes[v] or "Item")
+		end
 
 		v.ClearSetPoint = clearSetPoint
 	end

--- a/PetButton.lua
+++ b/PetButton.lua
@@ -156,18 +156,9 @@ function PetButtonPrototype:UpdateHotkeys()
 end
 
 function PetButtonPrototype:ShowButton()
-	self.pushedTexture:SetTexture(self.textureCache.pushed)
-	self.highlightTexture:SetTexture(self.textureCache.highlight)
-	local backdrop, gloss
-	if Masque then
-		backdrop, gloss = Masque:GetBackdrop(self), Masque:GetGloss(self)
-	end
-	-- Toggle backdrop/gloss
-	if backdrop then
-		backdrop:Show()
-	end
-	if gloss then
-		gloss:Show()
+	if not Masque then
+		self.pushedTexture:SetTexture(self.textureCache.pushed)
+		self.highlightTexture:SetTexture(self.textureCache.highlight)
 	end
 	self:SetAlpha(1.0)
 end
@@ -176,18 +167,9 @@ function PetButtonPrototype:HideButton()
 	self.textureCache.pushed = self.pushedTexture:GetTexture()
 	self.textureCache.highlight = self.highlightTexture:GetTexture()
 
-	self.pushedTexture:SetTexture("")
-	self.highlightTexture:SetTexture("")
-	local backdrop, gloss
-	if Masque then
-		backdrop, gloss = Masque:GetBackdrop(self), Masque:GetGloss(self)
-	end
-	-- Toggle backdrop/gloss
-	if backdrop then
-		backdrop:Hide()
-	end
-	if gloss then
-		gloss:Hide()
+	if not Masque then
+		self.pushedTexture:SetTexture("")
+		self.highlightTexture:SetTexture("")
 	end
 	if self.showgrid == 0 and not self.parent.config.showgrid then
 		self:SetAlpha(0.0)


### PR DESCRIPTION
The first commit  re-enables Bag Bar skinning for Masque and ensures that the proper type is passed to Masque. Feel free to tweak it or even not use it. Just throwing it out there as a quick fix.

The second commit fixes issues with PetButton skinning in Dragonflight. Primarily the issue with textures being stretched when a skin uses an atlas.

Some notes:

- Masque handles hiding the Gloss and Shadow on empty buttons automatically.
- The Backdrop shouldn't be hidden on empty buttons if the grid is enabled and the backdrop is enabled for the skin, so I removed that bit as it's unnecessary since the Backdrop visibility is also handled by Masque.