### PR TITLE
Fix Button Offset option not updating bars when changed

### DIFF
--- a/ActionBar.lua
+++ b/ActionBar.lua
@@ -242,15 +242,15 @@ function ActionBar:UpdateButtons(numbuttons, offset)
 
 	local buttons = self.buttons or {}
 
-	local updateStartValue = #buttons + 1
-	if self.currentButtonOffset ~= self.config.buttonOffset then
-		updateStartValue = 1
-	end
-
 	if offset then
 		self.config.buttonOffset = min(offset, 11)
 	else
 		offset = min(self.config.buttonOffset, 11)
+	end
+
+	local updateStartValue = #buttons + 1
+	if self.currentButtonOffset ~= offset then
+		updateStartValue = 1
 	end
 
 	local updateBindings = (numbuttons > #buttons)


### PR DESCRIPTION
The check whether a change was needed was comparing against old config value before updating the config value to the new requested value, skipping the actual updating of buttons until reloading interface or switching to and from a profile with different offset.