### PR TITLE
Bump toc to 10.0.2

### DIFF
--- a/Bartender4.toc
+++ b/Bartender4.toc
@@ -1,4 +1,4 @@
-## Interface: 100000
+## Interface: 100002
 ## Interface-Classic: 11403
 ## Interface-BCC: 20504
 ## Interface-Wrath: 30400


### PR DESCRIPTION
The latest release on curseforge is still flagged for 10.0.0, however all regions now have 10.0.2 unlocked :D