### PR TITLE
Fix the disappearing micro menu

### DIFF
--- a/MicroMenu.lua
+++ b/MicroMenu.lua
@@ -133,7 +133,7 @@ function MicroMenuMod:PET_BATTLE_CLOSE()
 end
 
 function MicroMenuMod:ActionBarController_UpdateAll()
-	if self.ownedByUI and ActionBarController_GetCurrentActionBarState() == LE_ACTIONBAR_STATE_MAIN and not (C_PetBattles and C_PetBattles.IsInBattle()) then
+	if self.ownedByUI and ActionBarController_GetCurrentActionBarState() == LE_ACTIONBAR_STATE_MAIN then
 		self:RestoreMicroButtonParent()
 		self:MicroMenuBarShow()
 	end
@@ -163,10 +163,7 @@ function MicroMenuMod:UpdateMicroButtonsParent(parent)
 	if parent == self.bar then
 		self.ownedByUI = false
 		return
-	end
-
-	-- any other parent then MainMenuBarArtFrame means its taken over by the Override bar or the PetBattleFrame
-	if parent and ((Bartender4.db.profile.blizzardVehicle and parent == OverrideActionBar) or parent == (PetBattleFrame and PetBattleFrame.BottomFrame.MicroButtonFrame)) then
+	else -- any other parent then MainMenuBarArtFrame means its taken over by the Override bar or the PetBattleFrame
 		self.ownedByUI = true
 		self:BlizzardBarShow()
 		return


### PR DESCRIPTION
### Issue
The micro menu is not properly restored in WoW Classic when a vehicle is left. This results in the micro menu disappearing when mounting the vehicle but not reappearing after leaving it. 

### Root cause
The root cause seems to be that `ActionBarController_UpdateAll` and `UpdateMicroButtonsParent` do not trigger `RestoreMicroButtonParent` after leaving a vehicle. I did not further investigate, but it seems as `(C_PetBattles and C_PetBattles.IsInBattle())` in `MicroMenuMod:ActionBarController_UpdateAll` does not work in WoW classic. Similarly, the if-condition in `MicroMenuMod:UpdateMicroButtonsParent` does not seem to work either.

### Discussion
The changes I made seem to work for Wotlk 3.4.147966. That means, the micro menu is properly hidden when in a vehicle and shown again after having it left. However, I'm not sure if my changes work for retail and since I don't play retail, I would be in need of aid here.
While testing I also had a few cases where, for some reason, the micro bar did show up only for some seconds after leaving a vehicle, but then disappearing again. I hope it was just too much coffee...

Fixes #154