### PR TITLE
Revert "Work-around issues with the PetBar not accepting modified key…

### DIFF
--- a/.luacheckrc
+++ b/.luacheckrc
@@ -84,7 +84,6 @@ read_globals = {
 	"SetBindingClick",
 	"SetCVar",
 	"SetModifiedClick",
-	"SetOverrideBinding",
 	"SetOverrideBindingClick",
 	"UnitClass",
 	"UnitFactionGroup",

--- a/.luacheckrc
+++ b/.luacheckrc
@@ -84,6 +84,7 @@ read_globals = {
 	"SetBindingClick",
 	"SetCVar",
 	"SetModifiedClick",
+	"SetOverrideBinding",
 	"SetOverrideBindingClick",
 	"UnitClass",
 	"UnitFactionGroup",

--- a/PetBar.lua
+++ b/PetBar.lua
@@ -79,11 +79,26 @@ function PetBarMod:ReassignBindings()
 	if InCombatLockdown() then return end
 	if not self.bar or not self.bar.buttons then return end
 	ClearOverrideBindings(self.bar)
-	for i = 1, 10 do
-		local button, real_button = ("BONUSACTIONBUTTON%d"):format(i), ("BT4PetButton%d"):format(i)
-		for k=1, select('#', GetBindingKey(button)) do
-			local key = select(k, GetBindingKey(button))
-			SetOverrideBindingClick(self.bar, false, key, real_button)
+
+	if not WoWRetail then
+		for i = 1, 10 do
+			local button, real_button = ("BONUSACTIONBUTTON%d"):format(i), ("BT4PetButton%d"):format(i)
+			for k=1, select('#', GetBindingKey(button)) do
+				local key = select(k, GetBindingKey(button))		
+				if self:IsKeybindWithModifier(key) then
+					SetOverrideBinding(self.bar, false, key, button)
+				else
+					SetOverrideBindingClick(self.bar, false, key, real_button)
+				end
+			end
+		end
+	else
+		for i = 1, 10 do
+			local button, real_button = ("BONUSACTIONBUTTON%d"):format(i), ("BT4PetButton%d"):format(i)
+			for k=1, select('#', GetBindingKey(button)) do
+				local key = select(k, GetBindingKey(button))
+				SetOverrideBindingClick(self.bar, false, key, real_button)
+			end
 		end
 	end
 end
@@ -150,4 +165,12 @@ function PetBar:ApplyConfig(config)
 	self:UpdateButtonLayout()
 	self:ForAll("Update")
 	self:ForAll("ApplyStyle", self.config.style)
+end
+
+function PetBarMod:IsKeybindWithModifier(key)
+	if key:find('^' .. "ALT") ~= nil then return true
+	elseif key:find('^' .. "CTRL") ~= nil then return true
+	elseif key:find('^' .. "SHIFT") ~= nil then return true
+	else return false
+	end
 end

--- a/PetBar.lua
+++ b/PetBar.lua
@@ -79,22 +79,11 @@ function PetBarMod:ReassignBindings()
 	if InCombatLockdown() then return end
 	if not self.bar or not self.bar.buttons then return end
 	ClearOverrideBindings(self.bar)
-
-	if not WoWRetail then
-		for i = 1, 10 do
-			local button, real_button = ("BONUSACTIONBUTTON%d"):format(i), ("CLICK BT4PetButton%d:LeftButton"):format(i)
-			for k=1, select('#', GetBindingKey(real_button)) do
-				local key = select(k, GetBindingKey(real_button))
-				SetOverrideBinding(self.bar, false, key, button)
-			end
-		end
-	else
-		for i = 1, 10 do
-			local button, real_button = ("BONUSACTIONBUTTON%d"):format(i), ("BT4PetButton%d"):format(i)
-			for k=1, select('#', GetBindingKey(button)) do
-				local key = select(k, GetBindingKey(button))
-				SetOverrideBindingClick(self.bar, false, key, real_button)
-			end
+	for i = 1, 10 do
+		local button, real_button = ("BONUSACTIONBUTTON%d"):format(i), ("BT4PetButton%d"):format(i)
+		for k=1, select('#', GetBindingKey(button)) do
+			local key = select(k, GetBindingKey(button))
+			SetOverrideBindingClick(self.bar, false, key, real_button)
 		end
 	end
 end


### PR DESCRIPTION
### Issue
The keybindings for the pet bar don't work at all when in a vehicle or a drake (e.g. in occulus). When disabling Bartender the issue is gone. So the current problem is that
- With the work-around of e79877f1e2e6b3621876a27fa6f00eed24e9cebe the petbar keybindings work for pets but not for vehicles at all
- Without the work-around the petbar keybindings with modifiers don't work for pets, but the keybindings work fine for vehicles 

### Root cause
~Looks like the quick fix of e79877f1e2e6b3621876a27fa6f00eed24e9cebe now causes problems in Wotlk 3.4.1.47966. If I revert this commit everything works smooth again.~
Edit: I was a bit overhasty with reverting e79877f1e2e6b3621876a27fa6f00eed24e9cebe. The issue with the modified keybindings on the petbar reappears when reverting. The root cause for the petbar keybindings not working when on vehicle is the work-around of e79877f1e2e6b3621876a27fa6f00eed24e9cebe, though.

### Solution
I don't have a definitive solution, but at least something that could improve the situation. I modified `PetBarMod:ReassignBindings` so that the work-around is only used for bindings with a modifier, and the "traditional" way is used for the others. As a result, the keybindings for pets work for both normal and modified bindings and when on a vehicle at least the normal keybindings work. Keybindings with modifiers still won't work when on a vehicle though. But I think it's worth adding this improvement to at least help all the people with non-modified keybindings on the petbar.