### PR TITLE
Fixes an issue where the last button coords are nil when coming out of vehicles

### DIFF
--- a/MicroMenu.lua
+++ b/MicroMenu.lua
@@ -188,18 +188,13 @@ function MicroMenuMod:UpdateMicroButtonsParent(parent)
 end
 
 function MicroMenuMod:MicroMenuBarShow()
-    -- Only "fix" button anchors if another frame that uses the MicroButtonBar isn't active.
-    if not self.ownedByUI then
-        if UpdateMicroButtonsParent then
-            UpdateMicroButtonsParent(self.bar)
-        end
-
-        -- Double-check Blizzard doesn't get nil values
-        lastButtonX = lastButtonX or 0
-        lastButtonY = lastButtonY or 0
-
-        self.bar:UpdateButtonLayout()
-    end
+	-- Only "fix" button anchors if another frame that uses the MicroButtonBar isn't active.
+	if not self.ownedByUI then
+		if UpdateMicroButtonsParent then
+			UpdateMicroButtonsParent(self.bar)
+		end
+		self.bar:UpdateButtonLayout()
+	end
 end
 
 function MicroMenuMod:BlizzardBarShow()
@@ -236,28 +231,23 @@ function MicroMenuBar:ApplyConfig(config)
 end
 
 function MicroMenuBar:UpdateButtonLayout()
-    ButtonBar.UpdateButtonLayout(self)
+	ButtonBar.UpdateButtonLayout(self)
 
-    if HelpMicroButton and StoreMicroButton then
-        -- Ensure lastButtonX and lastButtonY are always valid numbers
-        lastButtonX = lastButtonX or 0
-        lastButtonY = lastButtonY or 0
+	if not StoreMicroButton:IsShown() then
+		HelpMicroButton:Show()
+		HelpMicroButton:ClearAllPoints()
+		HelpMicroButton:SetAllPoints(StoreMicroButton)
+	else
+		HelpMicroButton:Hide()
+		HelpMicroButton:ClearAllPoints()
+		-- Assign a default anchor so GetLeft()/GetTop() return valid numbers
+		HelpMicroButton:SetPoint("CENTER", UIParent, "CENTER", 0, 0)
+	end
 
-        -- If the StoreButton is hidden we want to replace it with the Help button
-        if not StoreMicroButton:IsShown() then
-            HelpMicroButton:Show()
-            HelpMicroButton:ClearAllPoints()
-            HelpMicroButton:SetAllPoints(StoreMicroButton)
-        else
-            HelpMicroButton:Hide()
-            HelpMicroButton:ClearAllPoints()
-        end
-    end
-
-    if WoWClassic and GuildMicroButton then
-        GuildMicroButton:ClearAllPoints()
-        GuildMicroButton:SetAllPoints(SocialsMicroButton)
-    end
+	if WoWClassic and GuildMicroButton then
+		GuildMicroButton:ClearAllPoints()
+		GuildMicroButton:SetAllPoints(SocialsMicroButton)
+	end
 end
 
 if not WoWClassic and QueueStatusButton then

--- a/MicroMenu.lua
+++ b/MicroMenu.lua
@@ -188,13 +188,19 @@ function MicroMenuMod:UpdateMicroButtonsParent(parent)
 end
 
 function MicroMenuMod:MicroMenuBarShow()
-	-- Only "fix" button anchors if another frame that uses the MicroButtonBar isn't active.
-	if not self.ownedByUI then
-		if UpdateMicroButtonsParent then
-			UpdateMicroButtonsParent(self.bar)
-		end
-		self.bar:UpdateButtonLayout()
-	end
+    -- Only "fix" button anchors if another frame that uses the MicroButtonBar isn't active.
+    if not self.ownedByUI then
+        if UpdateMicroButtonsParent then
+            UpdateMicroButtonsParent(self.bar)
+        end
+
+        -- Ensure lastButtonX and lastButtonY are not nil before calling layout functions
+        if not lastButtonX or not lastButtonY then
+            lastButtonX, lastButtonY = 0, 0
+        end
+
+        self.bar:UpdateButtonLayout()
+    end
 end
 
 function MicroMenuMod:BlizzardBarShow()
@@ -234,6 +240,11 @@ function MicroMenuBar:UpdateButtonLayout()
 	ButtonBar.UpdateButtonLayout(self)
 
 	if HelpMicroButton and StoreMicroButton then
+		-- Ensure lastButtonX and lastButtonY are not nil before positioning
+		if lastButtonX == nil or lastButtonY == nil then
+			lastButtonX, lastButtonY = 0, 0  -- Set default values to prevent nil errors
+		end
+
 		-- If the StoreButton is hidden we want to replace it with the Help button
 		if not StoreMicroButton:IsShown() then
 			HelpMicroButton:Show()

--- a/MicroMenu.lua
+++ b/MicroMenu.lua
@@ -194,10 +194,9 @@ function MicroMenuMod:MicroMenuBarShow()
             UpdateMicroButtonsParent(self.bar)
         end
 
-        -- Ensure lastButtonX and lastButtonY are not nil before calling layout functions
-        if not lastButtonX or not lastButtonY then
-            lastButtonX, lastButtonY = 0, 0
-        end
+        -- Double-check Blizzard doesn't get nil values
+        lastButtonX = lastButtonX or 0
+        lastButtonY = lastButtonY or 0
 
         self.bar:UpdateButtonLayout()
     end
@@ -237,29 +236,28 @@ function MicroMenuBar:ApplyConfig(config)
 end
 
 function MicroMenuBar:UpdateButtonLayout()
-	ButtonBar.UpdateButtonLayout(self)
+    ButtonBar.UpdateButtonLayout(self)
 
-	if HelpMicroButton and StoreMicroButton then
-		-- Ensure lastButtonX and lastButtonY are not nil before positioning
-		if lastButtonX == nil or lastButtonY == nil then
-			lastButtonX, lastButtonY = 0, 0  -- Set default values to prevent nil errors
-		end
+    if HelpMicroButton and StoreMicroButton then
+        -- Ensure lastButtonX and lastButtonY are always valid numbers
+        lastButtonX = lastButtonX or 0
+        lastButtonY = lastButtonY or 0
 
-		-- If the StoreButton is hidden we want to replace it with the Help button
-		if not StoreMicroButton:IsShown() then
-			HelpMicroButton:Show()
-			HelpMicroButton:ClearAllPoints()
-			HelpMicroButton:SetAllPoints(StoreMicroButton)
-		else
-			HelpMicroButton:Hide()
-			HelpMicroButton:ClearAllPoints()
-		end
-	end
+        -- If the StoreButton is hidden we want to replace it with the Help button
+        if not StoreMicroButton:IsShown() then
+            HelpMicroButton:Show()
+            HelpMicroButton:ClearAllPoints()
+            HelpMicroButton:SetAllPoints(StoreMicroButton)
+        else
+            HelpMicroButton:Hide()
+            HelpMicroButton:ClearAllPoints()
+        end
+    end
 
-	if WoWClassic and GuildMicroButton then
-		GuildMicroButton:ClearAllPoints()
-		GuildMicroButton:SetAllPoints(SocialsMicroButton)
-	end
+    if WoWClassic and GuildMicroButton then
+        GuildMicroButton:ClearAllPoints()
+        GuildMicroButton:SetAllPoints(SocialsMicroButton)
+    end
 end
 
 if not WoWClassic and QueueStatusButton then


### PR DESCRIPTION
Noticed it happening when you mount (dismount?) cinderbees in the meadery.

Easiest test case for fix is in Sidestreet Sluice where you use "Mr. Delver". Upon exiting Mr. Delver you'll notice the problem.

I didn't notice any ill effects of implementing this change.

Fixes #226 