### PR TITLE
Micro button bar fixes

### DIFF
--- a/MicroMenu.lua
+++ b/MicroMenu.lua
@@ -31,10 +31,10 @@ if WoWClassicMists then
 		"QuestLogMicroButton",
 		"SocialsMicroButton",
 		"GuildMicroButton",
-		"EJMicroButton",
-		"CollectionsMicroButton",
 		"PVPMicroButton",
 		"LFGMicroButton",
+		"CollectionsMicroButton",
+		"EJMicroButton",
 		--"HelpMicroButton",
 		"StoreMicroButton",
 		"MainMenuMicroButton",
@@ -221,11 +221,13 @@ function MicroMenuMod:MicroMenuBarShow()
 end
 
 function MicroMenuMod:BlizzardBarShow()
-	if WoWClassicEra then
+	if WoWClassicMists then
 		-- Only reset button positions not set in MoveMicroButtons()
 		for i,v in pairs(self.bar.buttons) do
 			if v ~= CharacterMicroButton and v ~= PVPMicroButton then
-				v:ClearSetPoint(unpack(self.bar.anchors[i]))
+				-- The Blizzard UI has incorrect padding between these buttons
+				local point, relativeTo, relativePoint = unpack(self.bar.anchors[i])
+				v:ClearSetPoint(point, relativeTo, relativePoint, -2, 0)
 			end
 		end
 	end


### PR DESCRIPTION
This PR fixes two minor visual bugs in the micro button bar.

- Micro buttons were presented in a different order compared to the base UI.
- The Blizzard override bar didn't lay out the buttons correctly, resulting in incorrect horizontal padding and uneven rows.

<details>
<summary>Click to see comparisons</summary>

## Button Order

### Blizzard UI
<img width="553" height="88" alt="image" src="https://github.com/user-attachments/assets/3b6e13ef-49cb-4c2a-b83c-cf7dd035b9a9" />

### Before 
The PvP and LFG buttons should come before the collections button, and the encounter journal should come after that.

<img width="551" height="93" alt="image" src="https://github.com/user-attachments/assets/3bbdb97a-f83c-4b1a-8550-566fea2e5cce" />

### After
Fixed!

<img width="554" height="74" alt="image" src="https://github.com/user-attachments/assets/1470546b-66b8-4fec-a377-f2b3b037e909" />

## Override Bar

### Blizzard UI

Take note of all the blank space on the right.

<img width="348" height="173" alt="image" src="https://github.com/user-attachments/assets/480a1e8e-b12c-412c-818f-1694370ed0d9" />

### Before

Button anchor points aren't reset.

<img width="611" height="171" alt="image" src="https://github.com/user-attachments/assets/81b4a4ab-23f5-4f5c-9bd8-e4fc1427aa53" />

###  After

The anchors are set correctly. No more blank space!

<img width="340" height="171" alt="image" src="https://github.com/user-attachments/assets/f69796f6-c062-4321-be36-826863d08707" />

</details>

