### PR TITLE
MoP Beta - Fixes (Micro Menu and Dual Spec)

### DIFF
--- a/Bartender4.toc
+++ b/Bartender4.toc
@@ -1,6 +1,7 @@
 ## Interface: 110105,110107
 ## Interface-Classic: 11507
 ## Interface-Cata: 40402
+## Interface-MoP: 50500
 
 ## Title: Bartender4
 ## Notes: Simple and Advanced combined - Bartender4 ActionBar AddOn

--- a/MicroMenu.lua
+++ b/MicroMenu.lua
@@ -40,19 +40,21 @@ else
 end
 
 -- create prototype information
-local MicroMenuBar = setmetatable({}, {__index = ButtonBar})
+local MicroMenuBar = setmetatable({}, { __index = ButtonBar })
 
-local defaults = { profile = Bartender4.Util:Merge({
-	enabled = true,
-	vertical = false,
-	visibility = {
-		possess = false,
-	},
-	padding = WoWClassicEra and -3 or (WoWClassic and -4 or 1),
-	position = {
-		scale = WoWClassic and 0.8 or 1.0,
-	},
-}, Bartender4.ButtonBar.defaults) }
+local defaults = {
+	profile = Bartender4.Util:Merge({
+		enabled = true,
+		vertical = false,
+		visibility = {
+			possess = false,
+		},
+		padding = WoWClassicEra and -3 or (WoWClassic and -4 or 1),
+		position = {
+			scale = WoWClassic and 0.8 or 1.0,
+		},
+	}, Bartender4.ButtonBar.defaults)
+}
 
 function MicroMenuMod:OnInitialize()
 	self.db = Bartender4.db:RegisterNamespace("MicroMenu", defaults)
@@ -61,7 +63,8 @@ end
 
 function MicroMenuMod:OnEnable()
 	if not self.bar then
-		self.bar = setmetatable(Bartender4.ButtonBar:Create("MicroMenu", self.db.profile, L["Micro Menu"], true), {__index = MicroMenuBar})
+		self.bar = setmetatable(Bartender4.ButtonBar:Create("MicroMenu", self.db.profile, L["Micro Menu"], true),
+			{ __index = MicroMenuBar })
 		local buttons = {}
 
 		-- remove the LFG button on classic era
@@ -74,7 +77,7 @@ function MicroMenuMod:OnEnable()
 			tDeleteItem(BT_MICRO_BUTTONS, "GuildMicroButton")
 		end
 
-		for i=1, #BT_MICRO_BUTTONS do
+		for i = 1, #BT_MICRO_BUTTONS do
 			local button = _G[BT_MICRO_BUTTONS[i]]
 			if button then
 				table_insert(buttons, button)
@@ -87,11 +90,10 @@ function MicroMenuMod:OnEnable()
 			self.ownedByUI = (MicroMenu:GetParent() ~= UIParent)
 
 			if not self.ownedByUI then
-				for i,v in pairs(buttons) do
+				for i, v in pairs(buttons) do
 					v:SetParent(self.bar)
 				end
 			end
-
 		elseif self.bar.buttons[1]:GetParent() ~= MainMenuBarArtFrame then
 			self.ownedByUI = true
 		end
@@ -99,8 +101,8 @@ function MicroMenuMod:OnEnable()
 		MicroMenuMod.button_count = #buttons
 
 		self.bar.anchors = {}
-		for i,v in pairs(buttons) do
-			self.bar.anchors[i] = { v:GetPoint() }	-- Save orig button anchors.
+		for i, v in pairs(buttons) do
+			self.bar.anchors[i] = { v:GetPoint() } -- Save orig button anchors.
 			v:SetFrameLevel(self.bar:GetFrameLevel() + 1)
 			v.ClearSetPoint = self.bar.ClearSetPoint
 		end
@@ -153,7 +155,7 @@ end
 
 function MicroMenuMod:MicroMenuSetParent(_, parent)
 	if parent == UIParent then
-		for i,v in pairs(self.bar.buttons) do
+		for i, v in pairs(self.bar.buttons) do
 			v:SetParent(self.bar)
 		end
 
@@ -162,7 +164,7 @@ function MicroMenuMod:MicroMenuSetParent(_, parent)
 		return
 	end
 
-	for i,v in pairs(self.bar.buttons) do
+	for i, v in pairs(self.bar.buttons) do
 		v:SetParent(MicroMenu)
 	end
 
@@ -200,14 +202,13 @@ end
 function MicroMenuMod:BlizzardBarShow()
 	if WoWClassicEra then
 		-- Only reset button positions not set in MoveMicroButtons()
-		for i,v in pairs(self.bar.buttons) do
+		for i, v in pairs(self.bar.buttons) do
 			if v ~= CharacterMicroButton and v ~= PVPMicroButton then
 				v:ClearSetPoint(unpack(self.bar.anchors[i]))
 			end
 		end
 	end
 end
-
 
 if WoWClassic then
 	MicroMenuBar.button_width = 29
@@ -235,14 +236,25 @@ function MicroMenuBar:UpdateButtonLayout()
 
 	if HelpMicroButton and StoreMicroButton then
 		HelpMicroButton:ClearAllPoints()
-		HelpMicroButton:SetAllPoints(StoreMicroButton)
-		-- If the StoreButton is hidden we want to replace it with the Help button
+
+		local success = pcall(function()
+			HelpMicroButton:SetPoint("TOPLEFT", StoreMicroButton, "TOPLEFT", 0, 0)
+			HelpMicroButton:SetPoint("BOTTOMRIGHT", StoreMicroButton, "BOTTOMRIGHT", 0, 0)
+		end)
+
+		if not success then
+			HelpMicroButton:SetParent(UIParent)
+			HelpMicroButton:SetPoint("CENTER", UIParent, "CENTER", 0, 0)
+			HelpMicroButton:Hide()
+		end
+
 		if not StoreMicroButton:IsShown() then
 			HelpMicroButton:Show()
 		else
 			HelpMicroButton:Hide()
 		end
 	end
+
 
 	if WoWClassic and GuildMicroButton then
 		GuildMicroButton:ClearAllPoints()
@@ -254,19 +266,21 @@ if not WoWClassic and QueueStatusButton then
 	local QueueStatusMod = Bartender4:NewModule("QueueStatusButtonBar", "AceHook-3.0")
 
 	-- create prototype information
-	local QueueStatusBar = setmetatable({}, {__index = Bar})
+	local QueueStatusBar = setmetatable({}, { __index = Bar })
 
-	local queuedefaults = { profile = Bartender4.Util:Merge({
-		enabled = true,
-		visibility = {
-			possess = false,
-		},
-		position = {
-			x = -315,
-			y = 150,
-			point = "BOTTOMRIGHT",
-		},
-	}, Bartender4.Bar.defaults) }
+	local queuedefaults = {
+		profile = Bartender4.Util:Merge({
+			enabled = true,
+			visibility = {
+				possess = false,
+			},
+			position = {
+				x = -315,
+				y = 150,
+				point = "BOTTOMRIGHT",
+			},
+		}, Bartender4.Bar.defaults)
+	}
 
 	function QueueStatusMod:OnInitialize()
 		self.db = Bartender4.db:RegisterNamespace("QueueStatus", queuedefaults)
@@ -275,7 +289,8 @@ if not WoWClassic and QueueStatusButton then
 
 	function QueueStatusMod:OnEnable()
 		if not self.bar then
-			self.bar = setmetatable(Bartender4.Bar:Create("QueueStatus", self.db.profile, L["Queue Status"], 1), {__index = QueueStatusBar})
+			self.bar = setmetatable(Bartender4.Bar:Create("QueueStatus", self.db.profile, L["Queue Status"], 1),
+				{ __index = QueueStatusBar })
 			self.bar:SetSize(45, 45)
 			self.bar.content = QueueStatusButton
 			self.bar.content:SetParent(self.bar)

--- a/libs/LibDualSpec-1.0/LibDualSpec-1.0.lua
+++ b/libs/LibDualSpec-1.0/LibDualSpec-1.0.lua
@@ -1,0 +1,510 @@
+--[[
+LibDualSpec-1.0 - Adds dual spec support to individual AceDB-3.0 databases
+Copyright (C) 2009-2024 Adirelle
+
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+    * Redistributions of source code must retain the above copyright notice,
+      this list of conditions and the following disclaimer.
+    * Redistributions in binary form must reproduce the above copyright notice,
+      this list of conditions and the following disclaimer in the documentation
+      and/or other materials provided with the distribution.
+    * Redistribution of a stand alone version is strictly prohibited without
+      prior written authorization from the LibDualSpec project manager.
+    * Neither the name of the LibDualSpec authors nor the names of its contributors
+      may be used to endorse or promote products derived from this software without
+      specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+--]]
+
+-- Only load in Classic Era on Season of Discovery and Anniversary realms
+if WOW_PROJECT_ID == WOW_PROJECT_CLASSIC and C_Seasons.GetActiveSeason() ~= 2 and C_Seasons.GetActiveSeason() ~= 11 and C_Seasons.GetActiveSeason() ~= 12 then return end
+
+local MAJOR, MINOR = "LibDualSpec-1.0", 26
+assert(LibStub, MAJOR.." requires LibStub")
+local lib, minor = LibStub:NewLibrary(MAJOR, MINOR)
+if not lib then return end
+
+-- ----------------------------------------------------------------------------
+-- Library data
+-- ----------------------------------------------------------------------------
+
+lib.eventFrame = lib.eventFrame or CreateFrame("Frame")
+
+lib.registry = lib.registry or {}
+lib.options = lib.options or {}
+lib.mixin = lib.mixin or {}
+lib.upgrades = lib.upgrades or {}
+lib.currentSpec = tonumber(lib.currentSpec) or 0
+
+if minor and minor < 15 then
+	lib.talentsLoaded, lib.talentGroup = nil, nil
+	lib.specLoaded, lib.specGroup = nil, nil
+	lib.eventFrame:UnregisterAllEvents()
+	wipe(lib.options)
+end
+
+-- ----------------------------------------------------------------------------
+-- Locals
+-- ----------------------------------------------------------------------------
+
+local registry = lib.registry
+local options = lib.options
+local mixin = lib.mixin
+local upgrades = lib.upgrades
+
+-- "Externals"
+local AceDB3 = LibStub('AceDB-3.0', true)
+local AceDBOptions3 = LibStub('AceDBOptions-3.0', true)
+local AceConfigRegistry3 = LibStub('AceConfigRegistry-3.0', true)
+
+local isRetail = WOW_PROJECT_ID == WOW_PROJECT_MAINLINE
+local numSpecs = 2
+local specNames = {TALENT_SPEC_PRIMARY, TALENT_SPEC_SECONDARY}
+if isRetail then
+	-- class id specialization functions don't require player data to be loaded
+	local _, classId = UnitClassBase("player")
+	numSpecs = C_SpecializationInfo.GetNumSpecializationsForClassID(classId)
+	for i = 1, numSpecs do
+		local _, name = GetSpecializationInfoForClassID(classId, i)
+		specNames[i] = name
+	end
+end
+
+local GetSpecialization = isRetail and GetSpecialization or GetActiveTalentGroup or C_SpecializationInfo.GetActiveSpecGroup
+local CanPlayerUseTalentSpecUI = C_SpecializationInfo.CanPlayerUseTalentSpecUI or function()
+	return true, HELPFRAME_CHARACTER_BULLET5
+end
+
+-- ----------------------------------------------------------------------------
+-- Localization
+-- ----------------------------------------------------------------------------
+
+local L_ENABLED = "Enable spec profiles"
+local L_ENABLED_DESC = "When enabled, your profile will be set to the specified profile when you change specialization."
+local L_CURRENT = "%s - Active"
+
+do
+	local locale = GetLocale()
+	if locale == "deDE" then
+		L_ENABLED = "Spezialisierungsprofile aktivieren"
+		L_ENABLED_DESC = "Falls diese Option aktiviert ist, wird dein Profil auf das angegebene Profil gesetzt, wenn du die Spezialisierung wechselst."
+		L_CURRENT = "%s - Aktiv"
+	elseif locale == "esES" or locale == "esMX" then
+		L_ENABLED = "Activar perfiles de especialización"
+		L_ENABLED_DESC = "Cuando está habilitado, su perfil se establecerá en el perfil especificado cuando cambie de especialización."
+		L_CURRENT = "%s - Activo"
+	elseif locale == "frFR" then
+		L_ENABLED = "Activer les profils de spécialisation"
+		L_ENABLED_DESC = "Lorsque cette option est activée, votre profil sera défini sur le profil spécifié lorsque vous changerez de spécialisation."
+		L_CURRENT = "%s - Actifs"
+	elseif locale == "itIT" then
+		L_ENABLED = "Abilita i profili per la specializzazione"
+		L_ENABLED_DESC = "Quando abilitato, il tuo profilo verrà impostato in base alla specializzazione usata."
+		L_CURRENT = "%s - Attivi"
+	elseif locale == "koKR" then
+		L_ENABLED = "전문화 프로필 활성화"
+		L_ENABLED_DESC = "활성화하면 전문화를 변경할 때 프로필이 지정된 프로필로 설정됩니다."
+		L_CURRENT = "%s - 활성화"
+	elseif locale == "ptBR" then
+		L_ENABLED = "Ativar perfis de especialização"
+		L_ENABLED_DESC = "Quando ativado, seu perfil será definido para o perfil especificado quando você alterar a especialização."
+		L_CURRENT = "%s – ativo"
+	elseif locale == "ruRU" then
+		L_ENABLED = "Включить профили специализации"
+		L_ENABLED_DESC = "Если включено, ваш профиль будет зависеть от выбранной специализации."
+		L_CURRENT = "%s - активен"
+	elseif locale == "zhCN" then
+		L_ENABLED = "启用专精配置文件"
+		L_ENABLED_DESC = "当启用后，当切换专精时配置文件将设置为专精配置文件。"
+		L_CURRENT = "%s - 开启"
+	elseif locale == "zhTW" then
+		L_ENABLED = "啟用專精設定檔"
+		L_ENABLED_DESC = "當啟用後，當你切換專精時設定檔會設定為專精設定檔。"
+		L_CURRENT = "%s - 啟動"
+	end
+end
+
+-- ----------------------------------------------------------------------------
+-- Mixin
+-- ----------------------------------------------------------------------------
+
+--- Get dual spec feature status.
+-- @return (boolean) true is dual spec feature enabled.
+-- @name enhancedDB:IsDualSpecEnabled
+function mixin:IsDualSpecEnabled()
+	return lib.currentSpec > 0 and registry[self].db.char.enabled
+end
+
+--- Enable/disabled dual spec feature.
+-- @param enabled (boolean) true to enable dual spec feature, false to disable it.
+-- @name enhancedDB:SetDualSpecEnabled
+function mixin:SetDualSpecEnabled(enabled)
+	local db = registry[self].db.char
+	db.enabled = not not enabled
+
+	local currentProfile = self:GetCurrentProfile()
+	for i = 1, numSpecs do
+		-- nil out entries on disable, set nil entries to the current profile on enable
+		db[i] = enabled and (db[i] or currentProfile) or nil
+	end
+
+	self:CheckDualSpecState()
+end
+
+--- Get the profile assigned to a specialization.
+-- Defaults to the current profile.
+-- @param spec (number) the specialization index.
+-- @return (string) the profile name.
+-- @name enhancedDB:GetDualSpecProfile
+function mixin:GetDualSpecProfile(spec)
+	return registry[self].db.char[spec or lib.currentSpec] or self:GetCurrentProfile()
+end
+
+--- Set the profile assigned to a specialization.
+-- No validation are done to ensure the profile is valid.
+-- @param profileName (string) the profile name to use.
+-- @param spec (number) the specialization index.
+-- @name enhancedDB:SetDualSpecProfile
+function mixin:SetDualSpecProfile(profileName, spec)
+	spec = spec or lib.currentSpec
+	if spec < 1 or spec > numSpecs then return end
+
+	registry[self].db.char[spec] = profileName
+	self:CheckDualSpecState()
+end
+
+--- Check if a profile swap should occur.
+-- There is normally no reason to call this method directly as LibDualSpec
+-- takes care of calling it at the appropriate time.
+-- @name enhancedDB:CheckDualSpecState
+function mixin:CheckDualSpecState()
+	if not registry[self].db.char.enabled then return end
+	if lib.currentSpec == 0 then return end
+
+	local profileName = self:GetDualSpecProfile()
+	if profileName ~= self:GetCurrentProfile() then
+		self:SetProfile(profileName)
+	end
+end
+
+-- ----------------------------------------------------------------------------
+-- AceDB-3.0 support
+-- ----------------------------------------------------------------------------
+
+local function EmbedMixin(target)
+	for k,v in next, mixin do
+		rawset(target, k, v)
+	end
+end
+
+-- Upgrade settings from current/alternate system.
+-- This sets the current profile as the profile for your current spec and your
+-- swapped profile as the profile for the rest of your specs.
+local function UpgradeDatabase(target)
+	if lib.currentSpec == 0 then
+		upgrades[target] = true
+		return
+	end
+
+	local db = target:GetNamespace(MAJOR, true)
+	if db and db.char.profile then
+		for i = 1, numSpecs do
+			if i == lib.currentSpec then
+				db.char[i] = target:GetCurrentProfile()
+			else
+				db.char[i] = db.char.profile
+			end
+		end
+		db.char.profile = nil
+		db.char.specGroup = nil
+	end
+end
+
+-- Reset a spec profile to the current one if its profile is deleted.
+function lib:OnProfileDeleted(event, target, profileName)
+	local db = registry[target].db.char
+	if not db.enabled then return end
+
+	for i = 1, numSpecs do
+		if db[i] == profileName then
+			db[i] = target:GetCurrentProfile()
+		end
+	end
+end
+
+-- Actually enhance the database
+-- This is used on first initialization and everytime the database is reset using :ResetDB
+function lib:_EnhanceDatabase(event, target)
+	registry[target].db = target:GetNamespace(MAJOR, true) or target:RegisterNamespace(MAJOR)
+	EmbedMixin(target)
+	target:CheckDualSpecState()
+end
+
+--- Embed dual spec feature into an existing AceDB-3.0 database.
+-- LibDualSpec specific methods are added to the instance.
+-- @name LibDualSpec:EnhanceDatabase
+-- @param target (table) the AceDB-3.0 instance.
+-- @param name (string) a user-friendly name of the database (best bet is the addon name).
+function lib:EnhanceDatabase(target, name)
+	AceDB3 = AceDB3 or LibStub('AceDB-3.0', true)
+	if type(target) ~= "table" then
+		error("Usage: LibDualSpec:EnhanceDatabase(target, name): target should be a table.", 2)
+	elseif type(name) ~= "string" then
+		error("Usage: LibDualSpec:EnhanceDatabase(target, name): name should be a string.", 2)
+	elseif not AceDB3 or not AceDB3.db_registry[target] then
+		error("Usage: LibDualSpec:EnhanceDatabase(target, name): target should be an AceDB-3.0 database.", 2)
+	elseif target.parent then
+		error("Usage: LibDualSpec:EnhanceDatabase(target, name): cannot enhance a namespace.", 2)
+	elseif registry[target] then
+		return
+	end
+	registry[target] = { name = name }
+	UpgradeDatabase(target)
+	lib:_EnhanceDatabase("EnhanceDatabase", target)
+	target.RegisterCallback(lib, "OnDatabaseReset", "_EnhanceDatabase")
+	target.RegisterCallback(lib, "OnProfileDeleted")
+end
+
+-- ----------------------------------------------------------------------------
+-- AceDBOptions-3.0 support
+-- ----------------------------------------------------------------------------
+
+options.new = {
+	name = "New",
+	type = "input",
+	order = 30,
+	get = false,
+	set = function(info, value)
+		local db = info.handler.db
+		if db:IsDualSpecEnabled() then
+			db:SetDualSpecProfile(value, lib.currentSpec)
+		else
+			db:SetProfile(value)
+		end
+	end,
+}
+
+options.choose = {
+	name = "Existing Profiles",
+	type = "select",
+	order = 40,
+	get = "GetCurrentProfile",
+	set = "SetProfile",
+	values = "ListProfiles",
+	arg = "common",
+	disabled = function(info)
+		return info.handler.db:IsDualSpecEnabled()
+	end
+}
+
+options.enabled = {
+	type = "toggle",
+	name = "|cffffd200"..L_ENABLED.."|r",
+	desc = function()
+		local desc = L_ENABLED_DESC
+		if lib.currentSpec == 0 then
+			local _, reason = CanPlayerUseTalentSpecUI()
+			if not reason or reason == "" then
+				reason = TALENT_MICRO_BUTTON_NO_SPEC
+			end
+			desc = desc .. "\n\n" .. RED_FONT_COLOR:WrapTextInColorCode(reason)
+		end
+		return desc
+	end,
+	descStyle = "inline",
+	order = 41,
+	width = "full",
+	get = function(info) return info.handler.db:IsDualSpecEnabled() end,
+	set = function(info, value) info.handler.db:SetDualSpecEnabled(value) end,
+	disabled = function() return lib.currentSpec == 0 end,
+}
+
+local points = {}
+for i = 1, numSpecs do
+	options["specProfile" .. i] = {
+		type = "select",
+		name = function(info)
+			local specIndex = tonumber(info[#info]:sub(-1))
+			return lib.currentSpec == specIndex and L_CURRENT:format(specNames[specIndex]) or specNames[specIndex]
+		end,
+		desc = not isRetail and function(info)
+			if GetTalentTabInfo then -- Pre-5.0
+				local specIndex = tonumber(info[#info]:sub(-1))
+				local highPointsSpentIndex = nil
+				for treeIndex = 1, 3 do
+					local _, name, _, _, pointsSpent, _, previewPointsSpent = GetTalentTabInfo(treeIndex, nil, nil, specIndex)
+					if name then
+						local displayPointsSpent = pointsSpent + previewPointsSpent
+						points[treeIndex] = displayPointsSpent
+						if displayPointsSpent > 0 and (not highPointsSpentIndex or displayPointsSpent > points[highPointsSpentIndex]) then
+							highPointsSpentIndex = treeIndex
+						end
+					else
+						points[treeIndex] = 0
+					end
+				end
+				if highPointsSpentIndex then
+					points[highPointsSpentIndex] = GREEN_FONT_COLOR:WrapTextInColorCode(points[highPointsSpentIndex])
+				end
+				return ("|cffffffff%s / %s / %s|r"):format(unpack(points))
+			elseif C_SpecializationInfo.GetSpecialization then -- 5.0 - 9.x
+				local specGroup = tonumber(info[#info]:sub(-1))
+				local specIndex = C_SpecializationInfo.GetSpecialization(nil, nil, specGroup)
+				if specIndex then
+					local sex = UnitSex("player")
+					local _, specName = C_SpecializationInfo.GetSpecializationInfo(specIndex, nil, nil, sex)
+					return ("|cffffffff%s|r"):format(specName)
+				end
+			end
+		end or nil,
+		order = 42 + i,
+		get = function(info)
+			local specIndex = tonumber(info[#info]:sub(-1))
+			return info.handler.db:GetDualSpecProfile(specIndex)
+		end,
+		set = function(info, value)
+			local specIndex = tonumber(info[#info]:sub(-1))
+			info.handler.db:SetDualSpecProfile(value, specIndex)
+		end,
+		values = "ListProfiles",
+		arg = "common",
+		disabled = function(info) return not info.handler.db:IsDualSpecEnabled() end,
+	}
+end
+
+--- Embed dual spec options into an existing AceDBOptions-3.0 option table.
+-- @name LibDualSpec:EnhanceOptions
+-- @param optionTable (table) The option table returned by AceDBOptions-3.0.
+-- @param target (table) The AceDB-3.0 the options operate on.
+function lib:EnhanceOptions(optionTable, target)
+	AceDBOptions3 = AceDBOptions3 or LibStub('AceDBOptions-3.0', true)
+	AceConfigRegistry3 = AceConfigRegistry3 or LibStub('AceConfigRegistry-3.0', true)
+	if type(optionTable) ~= "table" then
+		error("Usage: LibDualSpec:EnhanceOptions(optionTable, target): optionTable should be a table.", 2)
+	elseif type(target) ~= "table" then
+		error("Usage: LibDualSpec:EnhanceOptions(optionTable, target): target should be a table.", 2)
+	elseif not AceDBOptions3 or not AceDBOptions3.optionTables[target] then
+		error("Usage: LibDualSpec:EnhanceOptions(optionTable, target): optionTable is not an AceDBOptions-3.0 table.", 2)
+	elseif optionTable.handler.db ~= target then
+		error("Usage: LibDualSpec:EnhanceOptions(optionTable, target): optionTable must be the option table of target.", 2)
+	elseif not registry[target] then
+		error("Usage: LibDualSpec:EnhanceOptions(optionTable, target): EnhanceDatabase should be called before EnhanceOptions(optionTable, target).", 2)
+	end
+
+	-- localize our replacements
+	options.new.name = optionTable.args.new.name
+	options.new.desc = optionTable.args.new.desc
+	options.choose.name = optionTable.args.choose.name
+	options.choose.desc = optionTable.args.choose.desc
+
+	-- add our new options
+	if not optionTable.plugins then
+		optionTable.plugins = {}
+	end
+	optionTable.plugins[MAJOR] = options
+end
+
+-- ----------------------------------------------------------------------------
+-- Upgrade existing
+-- ----------------------------------------------------------------------------
+
+for target in next, registry do
+	UpgradeDatabase(target)
+	EmbedMixin(target)
+	target:CheckDualSpecState()
+	local optionTable = AceDBOptions3 and AceDBOptions3.optionTables[target]
+	if optionTable then
+		lib:EnhanceOptions(optionTable, target)
+	end
+end
+
+-- ----------------------------------------------------------------------------
+-- Inspection
+-- ----------------------------------------------------------------------------
+
+do
+	local function iterator(t, key)
+		local data
+		key, data = next(t, key)
+		if key then
+			return key, data.name
+		end
+	end
+
+	--- Iterate through enhanced AceDB3.0 instances.
+	-- The iterator returns (instance, name) pairs where instance and name are the
+	-- arguments that were provided to lib:EnhanceDatabase.
+	-- @name LibDualSpec:IterateDatabases
+	-- @return Values to be used in a for .. in .. do statement.
+	function lib:IterateDatabases()
+		return iterator, lib.registry
+	end
+end
+
+-- ----------------------------------------------------------------------------
+-- Switching logic
+-- ----------------------------------------------------------------------------
+
+local function eventHandler(self, event)
+	local spec = GetSpecialization() or 0
+	-- Newly created characters start at 5 instead of 1 in 9.0.1.
+	if spec == 5 or not CanPlayerUseTalentSpecUI() then
+		spec = 0
+	end
+	lib.currentSpec = spec
+
+	if event == "PLAYER_LOGIN" then
+		self:UnregisterEvent(event)
+		self:RegisterEvent("PLAYER_ENTERING_WORLD")
+		if isRetail then
+			self:RegisterUnitEvent("PLAYER_SPECIALIZATION_CHANGED", "player")
+			self:RegisterEvent("PLAYER_LEVEL_CHANGED")
+		else
+			self:RegisterEvent("ACTIVE_TALENT_GROUP_CHANGED")
+		end
+	end
+
+	if spec > 0 and next(upgrades) then
+		for target in next, upgrades do
+			UpgradeDatabase(target)
+		end
+		wipe(upgrades)
+	end
+
+	for target in next, registry do
+		target:CheckDualSpecState()
+	end
+
+	if AceConfigRegistry3 and next(registry) then
+		-- Update the "Current" text in options
+		-- We don't get the key for the actual registered options table, and we can't
+		-- really check for our enhanced options without walking every options table,
+		-- so just refresh anything.
+		for appName in AceConfigRegistry3:IterateOptionsTables() do
+			AceConfigRegistry3:NotifyChange(appName)
+		end
+	end
+end
+
+lib.eventFrame:SetScript("OnEvent", eventHandler)
+if IsLoggedIn() then
+	eventHandler(lib.eventFrame, "PLAYER_LOGIN")
+else
+	lib.eventFrame:RegisterEvent("PLAYER_LOGIN")
+end
+

--- a/libs/LibDualSpec-1.0/LibDualSpec-1.0.toc
+++ b/libs/LibDualSpec-1.0/LibDualSpec-1.0.toc
@@ -1,0 +1,11 @@
+## Interface: 11506, 11507, 20504, 30404, 40402, 40401, 50500, 110105, 110107, 110100
+## LoadOnDemand: 1
+## Title: Lib: DualSpec-1.0
+## Version: v1.26.0
+## X-Date: 2025-05-17T2:22:02Z
+## Notes: Adds spec switching support to individual AceDB-3.0 databases.
+## Author: Adirelle, Nebula
+## OptionalDeps: Ace3
+
+LibStub.lua
+LibDualSpec-1.0.lua

--- a/libs/LibDualSpec-1.0/LibStub.lua
+++ b/libs/LibDualSpec-1.0/LibStub.lua
@@ -1,0 +1,30 @@
+-- LibStub is a simple versioning stub meant for use in Libraries.  http://www.wowace.com/wiki/LibStub for more info
+-- LibStub is hereby placed in the Public Domain Credits: Kaelten, Cladhaire, ckknight, Mikk, Ammo, Nevcairiel, joshborke
+local LIBSTUB_MAJOR, LIBSTUB_MINOR = "LibStub", 2  -- NEVER MAKE THIS AN SVN REVISION! IT NEEDS TO BE USABLE IN ALL REPOS!
+local LibStub = _G[LIBSTUB_MAJOR]
+
+if not LibStub or LibStub.minor < LIBSTUB_MINOR then
+	LibStub = LibStub or {libs = {}, minors = {} }
+	_G[LIBSTUB_MAJOR] = LibStub
+	LibStub.minor = LIBSTUB_MINOR
+	
+	function LibStub:NewLibrary(major, minor)
+		assert(type(major) == "string", "Bad argument #2 to `NewLibrary' (string expected)")
+		minor = assert(tonumber(strmatch(minor, "%d+")), "Minor version must either be a number or contain a number.")
+		
+		local oldminor = self.minors[major]
+		if oldminor and oldminor >= minor then return nil end
+		self.minors[major], self.libs[major] = minor, self.libs[major] or {}
+		return self.libs[major], oldminor
+	end
+	
+	function LibStub:GetLibrary(major, silent)
+		if not self.libs[major] and not silent then
+			error(("Cannot find a library instance of %q."):format(tostring(major)), 2)
+		end
+		return self.libs[major], self.minors[major]
+	end
+	
+	function LibStub:IterateLibraries() return pairs(self.libs) end
+	setmetatable(LibStub, { __call = LibStub.GetLibrary })
+end


### PR DESCRIPTION
## Summary
This PR includes several fixes to enhance compatibility and stability for Mists of Pandaria Classic.

## Changes Included
- Added new version of LibDualSpec: Resolved issues related to incorrect or missing dual spec configurations that could cause Lua errors or unexpected behavior when switching specs.
- Added Mists of Pandaria Build to .toc File: Included the appropriate interface version in the .toc file to support the Mists of Pandaria (MoP) build, ensuring proper loading and compatibility in that client version.
- Fixed MicroMenu Anchoring Bug: Addressed a cyclic dependency issue in MicroMenu.lua where HelpMicroButton was being anchored relative to StoreMicroButton, which in turn depended on the former. This caused UI errors and prevented correct rendering of the MicroMenu bar.
