### PR TITLE
Add mac command key as valid modifier

### DIFF
--- a/Options/StateBar.lua
+++ b/Options/StateBar.lua
@@ -251,6 +251,15 @@ function StateBar:GetOptionObject()
 					desc = (L["Configure actionbar paging when the %s key is down."]):format(L["SHIFT"]),
 					--width = "half",
 				},
+				cmd = {
+					order = 25,
+					type = "select",
+					name = L["COMMAND"],
+					arg = "states",
+					values = validStanceTable,
+					desc = (L["Configure actionbar paging when the %s key is down."]):format(L["COMMAND"]),
+					--width = "half",
+				},
 			},
 		},
 		stances = {

--- a/StateBar.lua
+++ b/StateBar.lua
@@ -31,6 +31,7 @@ local defaults = Bartender4.Util:Merge({
 		ctrl = 0,
 		alt = 0,
 		shift = 0,
+		cmd = 0,
 		stance = {
 			['*'] = {
 			},
@@ -83,7 +84,7 @@ end
 --------------------------------------------------------------
 -- Stance Management
 
-local modifiers = { "ctrl", "alt", "shift" }
+local modifiers = { "ctrl", "alt", "shift", "cmd" }
 
 -- specifiy the available stances for each class
 local DefaultStanceMap


### PR DESCRIPTION
Wow now allows to use cmd as a modifier, this simple change allows using the command key to switch state of bars.

