### PR TITLE
Update Bartender.toc to support Category

### DIFF
--- a/Bartender4.toc
+++ b/Bartender4.toc
@@ -10,6 +10,7 @@
 ## X-Email: h.leppkes at gmail dot com
 
 ## X-Category: Action Bars
+## Category: Action Bars
 ## X-Website: https://www.wowace.com/projects/bartender4/
 ## X-License: All rights reserved.
 ## X-Curse-Project-ID: 13501


### PR DESCRIPTION
This small PR adds Bartender to the 'Action Bars' category in WoW's AddOn List menu, by adding `Category: Action Bars` to the TOC alongside the existing X-Category in the header.

This will Fix #272 